### PR TITLE
Set up dev environment + add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a static personal blog built with Astro 7 (Svelte + MDX + Tailwind v4). It is the only service in the repo.
+
+- Dependencies install via `npm ci` (this is the startup update script). Node 22 is used.
+- Standard commands live in `package.json` scripts:
+  - Dev server: `npm run dev` (defaults to a random port; use `npm run dev -- --port 4321` to match `.vscode/launch.json`). Add `--host` to expose it.
+  - Lint/type check + build: `npm run build` (runs `astro check` then `astro build`).
+  - Preview built output: `npm run preview`.
+- Gotchas:
+  - `flake.nix` is pinned to `aarch64-darwin` and is not usable on the Linux cloud VM; ignore it and use `npm` directly.
+  - The dev server logs many `[Shiki] The language "..." doesn't exist, falling back to "plaintext"` warnings from code fences in blog posts. These are harmless and expected, not errors.
+  - CI (`.github/workflows/ci.yaml`) additionally runs Lighthouse (`lhci autorun`) after `npm run build`; that is a CI-only performance check, not needed for local dev.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set up and verified the development environment for this Astro blog (`fuku.day`).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting dev/build/preview commands and non-obvious gotchas.
- Configured the startup update script to `npm ci`.

## Environment
- Astro 7 static blog (Svelte + MDX + Tailwind v4), Node 22, npm. Single service.

## Testing
- `npm ci` — dependencies installed cleanly.
- `npm run build` — `astro check` + build succeeded (27 pages built).
- `npm run dev -- --port 4321 --host` — dev server serves HTTP 200; homepage, `/blog/`, and individual articles render correctly (verified in browser).

## Walkthrough
[astro_blog_navigation_demo.mp4](https://cursor.com/agents/bc-25d840bc-76a0-4289-a44e-addffa8652f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fastro_blog_navigation_demo.mp4)
Navigating homepage → blog index → individual article, all rendering correctly.

[Homepage](https://cursor.com/agents/bc-25d840bc-76a0-4289-a44e-addffa8652f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Blog index](https://cursor.com/agents/bc-25d840bc-76a0-4289-a44e-addffa8652f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_index.webp)
[Blog article](https://cursor.com/agents/bc-25d840bc-76a0-4289-a44e-addffa8652f3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_article.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25d840bc-76a0-4289-a44e-addffa8652f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25d840bc-76a0-4289-a44e-addffa8652f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

